### PR TITLE
Add Makefile for easy building without CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,133 @@
+#!/usr/bin/make -f
+
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+COMMIT := $(shell git log -1 --format='%H')
+BINDIR ?= $(GOPATH)/bin
+APP = ./app
+
+# don't override user values
+ifeq (,$(VERSION))
+  VERSION := $(shell git describe --tags)
+  # if VERSION is empty, then populate it with branch's name and raw commit hash
+  ifeq (,$(VERSION))
+    VERSION := $(BRANCH)-$(COMMIT)
+  endif
+endif
+
+PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
+LEDGER_ENABLED ?= true
+SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
+BFT_VERSION := $(shell go list -m github.com/cometbft/cometbft | sed 's:.* ::') # grab everything after the space in "github.com/cometbft/cometbft v0.34.7"
+DOCKER := $(shell which docker)
+DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf:1.0.0-rc8
+BUILDDIR ?= $(CURDIR)/build
+export GO111MODULE = on
+
+# process build tags
+
+build_tags = netgo
+ifeq ($(LEDGER_ENABLED),true)
+  ifeq ($(OS),Windows_NT)
+    GCCEXE = $(shell where gcc.exe 2> NUL)
+    ifeq ($(GCCEXE),)
+      $(error gcc.exe not installed for ledger support, please install or set LEDGER_ENABLED=false)
+    else
+      build_tags += ledger
+    endif
+  else
+    UNAME_S = $(shell uname -s)
+    ifeq ($(UNAME_S),OpenBSD)
+      $(warning OpenBSD detected, disabling ledger support (https://github.com/cosmos/cosmos-sdk/issues/1988))
+    else
+      GCC = $(shell command -v gcc 2> /dev/null)
+      ifeq ($(GCC),)
+        $(error gcc not installed for ledger support, please install or set LEDGER_ENABLED=false)
+      else
+        build_tags += ledger
+      endif
+    endif
+  endif
+endif
+
+ifeq (cleveldb,$(findstring cleveldb,$(EXRP_BUILD_OPTIONS)))
+  build_tags += gcc cleveldb
+endif
+build_tags += $(BUILD_TAGS)
+build_tags := $(strip $(build_tags))
+
+whitespace :=
+whitespace += $(whitespace)
+comma := ,
+build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
+
+# process linker flags
+
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=exrp \
+		  -X github.com/cosmos/cosmos-sdk/version.AppName=exrpd \
+		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
+			-X github.com/cometbft/cometbft/version.TMCoreSemVer=$(BFT_VERSION)
+
+ifeq (cleveldb,$(findstring cleveldb,$(EXRP_BUILD_OPTIONS)))
+  ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=cleveldb
+endif
+ifeq ($(LINK_STATICALLY),true)
+  ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
+endif
+ifeq (,$(findstring nostrip,$(EXRP_BUILD_OPTIONS)))
+  ldflags += -w -s
+endif
+ldflags += $(LDFLAGS)
+ldflags := $(strip $(ldflags))
+
+BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
+# check for nostrip option
+ifeq (,$(findstring nostrip,$(EXRP_BUILD_OPTIONS)))
+  BUILD_FLAGS += -trimpath
+endif
+ 
+#$(info $$BUILD_FLAGS is [$(BUILD_FLAGS)])
+
+all: install
+	@echo "--> project root: go mod tidy"	
+	@go mod tidy			
+	@echo "--> project root: linting --fix"	
+	@GOGC=1 golangci-lint run --fix --timeout=8m
+
+install: go.sum
+	go install -mod=readonly $(BUILD_FLAGS) ./cmd/exrpd
+
+build:
+	go build $(BUILD_FLAGS) -o bin/exrpd ./cmd/exrpd
+
+
+###############################################################################
+###                                Protobuf                                 ###
+###############################################################################
+
+protoVer=0.13.1
+protoImageName=ghcr.io/cosmos/proto-builder:$(protoVer)
+protoImage=$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(protoImageName)
+
+proto-all: proto-format proto-lint proto-gen
+
+proto-gen:
+	@echo "Generating Protobuf files"
+	@$(protoImage) sh ./scripts/protocgen.sh
+
+proto-swagger-gen:
+	@echo "Generating Protobuf Swagger"
+	@$(protoImage) sh ./scripts/protoc-swagger-gen.sh
+	$(MAKE) update-swagger-docs
+
+proto-format:
+	@$(protoImage) find ./ -name "*.proto" -exec clang-format -i {} \;
+
+proto-lint:
+	@$(protoImage) buf lint --error-format=json
+
+proto-check-breaking:
+	@$(protoImage) buf breaking --against $(HTTPS_GIT)#branch=main
+
+.PHONY: proto-all proto-gen proto-gen-any proto-swagger-gen proto-format proto-lint proto-check-breaking proto-update-deps docs

--- a/app/app.go
+++ b/app/app.go
@@ -2,15 +2,16 @@ package app
 
 import (
 	"encoding/json"
-	poaante "github.com/Peersyst/exrp/x/poa/ante"
+	"io"
+	"os"
+	"path/filepath"
+
+	poaante "github.com/Peersyst/exrp/v2/x/poa/ante"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	ethante "github.com/evmos/evmos/v15/app/ante/evm"
 	"github.com/spf13/cast"
-	"io"
-	"os"
-	"path/filepath"
 
 	"cosmossdk.io/math"
 
@@ -21,7 +22,7 @@ import (
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	"cosmossdk.io/simapp"
 	simappparams "cosmossdk.io/simapp/params"
-	"github.com/Peersyst/exrp/x/poa"
+	"github.com/Peersyst/exrp/v2/x/poa"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
 	"github.com/cosmos/cosmos-sdk/x/auth/posthandler"
@@ -105,13 +106,14 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
-	"github.com/Peersyst/exrp/docs"
-	poakeeper "github.com/Peersyst/exrp/x/poa/keeper"
-	poatypes "github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/docs"
+	poakeeper "github.com/Peersyst/exrp/v2/x/poa/keeper"
+	poatypes "github.com/Peersyst/exrp/v2/x/poa/types"
 
-	// "github.com/Peersyst/exrp/app/ante"
+	// "github.com/Peersyst/exrp/v2/app/ante"
 	"github.com/evmos/evmos/v15/app/ante"
 	srvflags "github.com/evmos/evmos/v15/server/flags"
 

--- a/app/simulation_test.go
+++ b/app/simulation_test.go
@@ -1,7 +1,11 @@
 package app_test
 
 import (
-	"github.com/Peersyst/exrp/app"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Peersyst/exrp/v2/app"
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -15,9 +19,6 @@ import (
 	ethante "github.com/evmos/evmos/v15/app/ante/evm"
 	evmostypes "github.com/evmos/evmos/v15/types"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
-	"time"
 )
 
 func init() {

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -3,7 +3,7 @@ package app
 import (
 	"fmt"
 
-	v2 "github.com/Peersyst/exrp/app/upgrades/v2"
+	v2 "github.com/Peersyst/exrp/v2/app/upgrades/v2"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"

--- a/cmd/exrpd/cmd/config.go
+++ b/cmd/exrpd/cmd/config.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/Peersyst/exrp/app"
+	"github.com/Peersyst/exrp/v2/app"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethermint "github.com/evmos/evmos/v15/types"
 )

--- a/cmd/exrpd/cmd/root.go
+++ b/cmd/exrpd/cmd/root.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
-	simappparams "cosmossdk.io/simapp/params"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	simappparams "cosmossdk.io/simapp/params"
 	dbm "github.com/cometbft/cometbft-db"
 	tmcfg "github.com/cometbft/cometbft/config"
 	tmcli "github.com/cometbft/cometbft/libs/cli"
@@ -31,12 +35,10 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"io"
-	"os"
-	"path/filepath"
+
 	// this line is used by starport scaffolding # root/moduleImport
 
-	"github.com/Peersyst/exrp/app"
+	"github.com/Peersyst/exrp/v2/app"
 	ethermintclient "github.com/evmos/evmos/v15/client"
 	ethermintserver "github.com/evmos/evmos/v15/server"
 	ethermintservercfg "github.com/evmos/evmos/v15/server/config"

--- a/cmd/exrpd/main.go
+++ b/cmd/exrpd/main.go
@@ -6,8 +6,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	"github.com/Peersyst/exrp/app"
-	"github.com/Peersyst/exrp/cmd/exrpd/cmd"
+	"github.com/Peersyst/exrp/v2/app"
+	"github.com/Peersyst/exrp/v2/cmd/exrpd/cmd"
 )
 
 func main() {

--- a/proto/packages/blockchain/poa/genesis.proto
+++ b/proto/packages/blockchain/poa/genesis.proto
@@ -4,7 +4,7 @@ package packages.blockchain.poa;
 import "gogoproto/gogo.proto";
 import "packages/blockchain/poa/params.proto";
 
-option go_package = "github.com/Peersyst/exrp/x/poa/types";
+option go_package = "github.com/Peersyst/exrp/v2/x/poa/types";
 
 // GenesisState defines the poa module's genesis state.
 message GenesisState {

--- a/proto/packages/blockchain/poa/params.proto
+++ b/proto/packages/blockchain/poa/params.proto
@@ -3,7 +3,7 @@ package packages.blockchain.poa;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/Peersyst/exrp/x/poa/types";
+option go_package = "github.com/Peersyst/exrp/v2/x/poa/types";
 
 // Params defines the parameters for the module.
 message Params {

--- a/proto/packages/blockchain/poa/query.proto
+++ b/proto/packages/blockchain/poa/query.proto
@@ -6,7 +6,7 @@ import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "packages/blockchain/poa/params.proto";
 
-option go_package = "github.com/Peersyst/exrp/x/poa/types";
+option go_package = "github.com/Peersyst/exrp/v2/x/poa/types";
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/packages/blockchain/poa/tx.proto
+++ b/proto/packages/blockchain/poa/tx.proto
@@ -8,7 +8,7 @@ import "cosmos/staking/v1beta1/staking.proto";
 import "google/protobuf/any.proto";
 import "amino/amino.proto";
 
-option go_package = "github.com/Peersyst/exrp/x/poa/types";
+option go_package = "github.com/Peersyst/exrp/v2/x/poa/types";
 
 // Msg defines the Msg service.
 service Msg {

--- a/tests/e2e/poa/add_validator_test.go
+++ b/tests/e2e/poa/add_validator_test.go
@@ -1,7 +1,7 @@
 package poa_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
+	"github.com/Peersyst/exrp/v2/tests/e2e"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )

--- a/tests/e2e/poa/ante_handler_test.go
+++ b/tests/e2e/poa/ante_handler_test.go
@@ -1,8 +1,9 @@
 package poa_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
 	"strings"
+
+	"github.com/Peersyst/exrp/v2/tests/e2e"
 )
 
 func (s *TestSuite) Test_AnteHandlerForbiddenTransactions() {

--- a/tests/e2e/poa/delegation_test.go
+++ b/tests/e2e/poa/delegation_test.go
@@ -1,7 +1,7 @@
 package poa_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
+	"github.com/Peersyst/exrp/v2/tests/e2e"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/tests/e2e/poa/poa_suite_test.go
+++ b/tests/e2e/poa/poa_suite_test.go
@@ -1,10 +1,11 @@
 package poa_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
-	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
+
+	"github.com/Peersyst/exrp/v2/tests/e2e"
+	"github.com/stretchr/testify/suite"
 )
 
 type TestSuite struct {

--- a/tests/e2e/poa/remove_validator_test.go
+++ b/tests/e2e/poa/remove_validator_test.go
@@ -1,10 +1,11 @@
 package poa_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
+	"time"
+
+	"github.com/Peersyst/exrp/v2/tests/e2e"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
-	"time"
 )
 
 func (s *TestSuite) Test_RemoveNonexistentValidator() {

--- a/tests/e2e/poa/unbonding/suite_test.go
+++ b/tests/e2e/poa/unbonding/suite_test.go
@@ -1,10 +1,11 @@
 package unbonding_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
-	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
+
+	"github.com/Peersyst/exrp/v2/tests/e2e"
+	"github.com/stretchr/testify/suite"
 )
 
 type TestSuite struct {

--- a/tests/e2e/poa/unbonding/unbonding_test.go
+++ b/tests/e2e/poa/unbonding/unbonding_test.go
@@ -1,10 +1,11 @@
 package unbonding_test
 
 import (
-	"github.com/Peersyst/exrp/tests/e2e"
-	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"sync"
 	"time"
+
+	"github.com/Peersyst/exrp/v2/tests/e2e"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 func (s *TestSuite) Test_AddUnbondingValidator() {

--- a/tests/e2e/test_suite.go
+++ b/tests/e2e/test_suite.go
@@ -2,10 +2,11 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/Peersyst/exrp/testutil/network"
+	"time"
+
+	"github.com/Peersyst/exrp/v2/testutil/network"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/suite"
-	"time"
 )
 
 type IntegrationTestSuite struct {

--- a/tests/e2e/util_transaction.go
+++ b/tests/e2e/util_transaction.go
@@ -2,13 +2,14 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/Peersyst/exrp/x/poa/types"
+	"time"
+
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/spf13/cobra"
-	"time"
 
-	"github.com/Peersyst/exrp/testutil/network"
+	"github.com/Peersyst/exrp/v2/testutil/network"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/testutil"

--- a/testutil/abci.go
+++ b/testutil/abci.go
@@ -7,7 +7,7 @@ import (
 	tmtypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Peersyst/exrp/app"
+	"github.com/Peersyst/exrp/v2/app"
 )
 
 // Commit commits a block at a given time. Reminder: At the end of each

--- a/testutil/fund.go
+++ b/testutil/fund.go
@@ -16,7 +16,7 @@
 package testutil
 
 import (
-	poatypes "github.com/Peersyst/exrp/x/poa/types"
+	poatypes "github.com/Peersyst/exrp/v2/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -33,7 +33,7 @@ import (
 
 	"cosmossdk.io/simapp"
 	"cosmossdk.io/simapp/params"
-	"github.com/Peersyst/exrp/app"
+	"github.com/Peersyst/exrp/v2/app"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"

--- a/testutil/network/network_test.go
+++ b/testutil/network/network_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/Peersyst/exrp/testutil/network"
+	"github.com/Peersyst/exrp/v2/testutil/network"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/evmos/evmos/v15/server/config"
 )

--- a/testutil/tx/cosmos.go
+++ b/testutil/tx/cosmos.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 
-	"github.com/Peersyst/exrp/app"
+	"github.com/Peersyst/exrp/v2/app"
 	"github.com/evmos/evmos/v15/utils"
 )
 

--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
-	"github.com/Peersyst/exrp/app"
+	"github.com/Peersyst/exrp/v2/app"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	cryptocodec "github.com/evmos/evmos/v15/crypto/codec"
 	"github.com/evmos/evmos/v15/ethereum/eip712"

--- a/x/poa/client/cli/query.go
+++ b/x/poa/client/cli/query.go
@@ -10,7 +10,7 @@ import (
 	// "github.com/cosmos/cosmos-sdk/client/flags"
 	// sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module

--- a/x/poa/client/cli/query_params.go
+++ b/x/poa/client/cli/query_params.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"

--- a/x/poa/client/cli/tx.go
+++ b/x/poa/client/cli/tx.go
@@ -2,13 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	stakingcli "github.com/cosmos/cosmos-sdk/x/staking/client/cli"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	flag "github.com/spf13/pflag"
-	"strings"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"

--- a/x/poa/keeper/genesis.go
+++ b/x/poa/keeper/genesis.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/poa/keeper/keeper.go
+++ b/x/poa/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -14,7 +15,7 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 )
 
 type (

--- a/x/poa/keeper/msg_server.go
+++ b/x/poa/keeper/msg_server.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 )
 
 type msgServer struct {

--- a/x/poa/keeper/msg_server_add_validator.go
+++ b/x/poa/keeper/msg_server_add_validator.go
@@ -2,9 +2,10 @@ package keeper
 
 import (
 	"context"
+
 	"github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types"
 )

--- a/x/poa/keeper/msg_server_remove_validator.go
+++ b/x/poa/keeper/msg_server_remove_validator.go
@@ -2,10 +2,11 @@ package keeper
 
 import (
 	"context"
+
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/poa/keeper/params.go
+++ b/x/poa/keeper/params.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/poa/keeper/query.go
+++ b/x/poa/keeper/query.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/poa/keeper/query_params.go
+++ b/x/poa/keeper/query_params.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/x/poa/module.go
+++ b/x/poa/module.go
@@ -12,9 +12,9 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 
-	"github.com/Peersyst/exrp/x/poa/client/cli"
-	"github.com/Peersyst/exrp/x/poa/keeper"
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/client/cli"
+	"github.com/Peersyst/exrp/v2/x/poa/keeper"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/poa/module_simulation.go
+++ b/x/poa/module_simulation.go
@@ -3,9 +3,9 @@ package poa
 import (
 	"math/rand"
 
-	"github.com/Peersyst/exrp/testutil/sample"
-	poasimulation "github.com/Peersyst/exrp/x/poa/simulation"
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/testutil/sample"
+	poasimulation "github.com/Peersyst/exrp/v2/x/poa/simulation"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"

--- a/x/poa/simulation/add_validator.go
+++ b/x/poa/simulation/add_validator.go
@@ -3,7 +3,7 @@ package simulation
 import (
 	"math/rand"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"

--- a/x/poa/simulation/helpers.go
+++ b/x/poa/simulation/helpers.go
@@ -1,14 +1,15 @@
 package simulation
 
 import (
-	"github.com/Peersyst/exrp/testutil/sims"
-	"github.com/Peersyst/exrp/x/poa/types"
+	"math/rand"
+
+	"github.com/Peersyst/exrp/v2/testutil/sims"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
-	"math/rand"
 )
 
 // FindAccount find a specific address from an account list

--- a/x/poa/simulation/remove_validator.go
+++ b/x/poa/simulation/remove_validator.go
@@ -3,7 +3,7 @@ package simulation
 import (
 	"math/rand"
 
-	"github.com/Peersyst/exrp/x/poa/types"
+	"github.com/Peersyst/exrp/v2/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"


### PR DESCRIPTION
# PR Name
Add Makefile for easy building without CLI
Fix go package name to match v2 version

## Motivation 💡

Without proper package name the node can't build
Without a proper Makefile the only way to build the node is trough ignite-cli, which is not ideal in a production environment

## Changes 🛠

We implemented a generic makefile that allows to:

- Generate code based on proto files
- Build exrpd with useful flags: ledger support, cleveldb, rocksdb
- Add version info to exrpd version --long

## How to use

```
cd path/to/repo
make install
```

## Considerations 🤔

It might be useful to add a binary build to releases as well, if needed we can provide github workflows for this.
