### PR TITLE
[FIX] Upgrade v3 error

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -5,6 +5,11 @@ on:
         branches:
             - "main"
 
+concurrency:
+  # Cancel old runs if there is a new commit in the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     integration:
         runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,11 @@ on:
     pull_request:
         types: [opened, synchronize]
 
+concurrency:
+    # Cancel old runs if there is a new commit in the same branch
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     integration:
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ on:
         description: Is this the latest release
         type: boolean
         required: true
-
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -36,7 +36,7 @@ func (app *App) setupUpgradeHandlers() {
 			app.EvmKeeper,
 			app.Erc20Keeper,
 			app.AccountKeeper,
-			app.StakingKeeper,
+			app.BankKeeper,
 		),
 	)
 

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -56,6 +56,14 @@ func CreateUpgradeHandler(
 			return nil, err
 		}
 
+		/** Custom migrations **/
+		// Disable default EVM Channels
+		params := ek.GetParams(ctx)
+		params.EVMChannels = []string{}
+		if err := ek.SetParams(ctx, params); err != nil {
+			logger.Error("failed to remove EVMChannels from evm params", "error", err.Error())
+			return nil, err
+		}
 		// Add XRP bank metadata for ERC20 recognition
 		bk.SetDenomMetaData(ctx, banktypes.Metadata{
 			Base: "axrp",

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -4,16 +4,15 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	"github.com/ethereum/go-ethereum/common"
 	v16 "github.com/evmos/evmos/v19/app/upgrades/v16"
 	v192 "github.com/evmos/evmos/v19/app/upgrades/v19_2"
 	"github.com/evmos/evmos/v19/precompiles/bech32"
 	"github.com/evmos/evmos/v19/precompiles/p256"
 	erc20keeper "github.com/evmos/evmos/v19/x/erc20/keeper"
-	erc20types "github.com/evmos/evmos/v19/x/erc20/types"
 	evmkeeper "github.com/evmos/evmos/v19/x/evm/keeper"
-	stakingkeeper "github.com/evmos/evmos/v19/x/staking/keeper"
 )
 
 // CreateUpgradeHandler creates an SDK upgrade handler for v13
@@ -23,44 +22,61 @@ func CreateUpgradeHandler(
 	ek *evmkeeper.Keeper,
 	erc20Keeper erc20keeper.Keeper,
 	ak authkeeper.AccountKeeper,
-	sk *stakingkeeper.Keeper,
+	bk bankkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
-
-		/**
-		Evmos v16 upgrades
-		*/
-		// enable secp256r1 and bech32 precompile on testnet
-		p256Address := p256.Precompile{}.Address()
-		bech32Address := bech32.Precompile{}.Address()
-		if err := ek.EnableStaticPrecompiles(ctx, p256Address, bech32Address); err != nil {
-			logger.Error("failed to enable precompiles", "error", err.Error())
-			return nil, err
-		}
+		/** Evmos v16 upgrades (pre-module upgrades) **/
 		// Add Burner role to fee collector
 		if err := v16.MigrateFeeCollector(ak, ctx); err != nil {
 			logger.Error("failed to migrate the fee collector", "error", err.Error())
 			return nil, err
 		}
 
-		/**
-		Evmos v19 upgrades
-		*/
-		// Register gas token as a token pair in erc20 module
-		pair := erc20types.NewTokenPair(
-			common.HexToAddress(erc20types.WEVMOSContractMainnet),
-			sk.BondDenom(ctx),
-			erc20types.OWNER_MODULE,
-		)
-		erc20Keeper.SetToken(ctx, pair)
+		/** Evmos v19 upgrades (pre-module upgrades) **/
 		// Add code extensions
 		if err := v192.AddCodeToERC20Extensions(ctx, logger, erc20Keeper); err != nil {
 			return nil, err
 		}
 
-		// Leave modules are as-is to avoid running InitGenesis.
+		/** Module upgrades **/
 		logger.Debug("running module migrations ...")
-		return mm.RunMigrations(ctx, configurator, vm)
+		versionMap, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			logger.Error("failed to migrate modules", "error", err.Error())
+			return nil, err
+		}
+
+		/** Evmos v16 upgrades (post-module upgrades) **/
+		// enable secp256r1 and bech32 precompiles
+		p256Address := p256.Precompile{}.Address()
+		bech32Address := bech32.Precompile{}.Address()
+		if err := ek.EnableStaticPrecompiles(ctx, p256Address, bech32Address); err != nil {
+			logger.Error("failed to enable precompiles", "error", err.Error())
+			return nil, err
+		}
+
+		// Add XRP bank metadata for ERC20 recognition
+		bk.SetDenomMetaData(ctx, banktypes.Metadata{
+			Base: "axrp",
+			DenomUnits: []*banktypes.DenomUnit{
+				{
+					Denom:    "axrp",
+					Aliases:  []string{"attoxrp"},
+					Exponent: 0,
+				},
+				{
+					Denom:    "xrp",
+					Aliases:  []string{},
+					Exponent: 18,
+				},
+			},
+			Description: "The native currency of the XRP Ledger",
+			Display:     "xrp",
+			Name:        "XRP",
+			Symbol:      "XRP",
+		})
+
+		return versionMap, nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -237,7 +237,7 @@ replace (
 	// use Evmos geth fork
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc4
 	// use exrp Evmos fork
-	github.com/evmos/evmos/v19 => github.com/Peersyst/evmos/v19 v19.2.0-exrp.0
+	github.com/evmos/evmos/v19 => github.com/Peersyst/evmos/v19 v19.2.0-exrp.5
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// replace broken goleveldb

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Peersyst/evmos/v19 v19.2.0-exrp.5 h1:zrnwpBX6Ake5m0JW+ARKZcVK+B6n7wZErR1W7L4MqrI=
+github.com/Peersyst/evmos/v19 v19.2.0-exrp.5/go.mod h1:Lhs/n3iXgIb1uc5gYljhxzl80i9z5Lhs6GsPrlMMvg4=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/go.sum
+++ b/go.sum
@@ -229,8 +229,6 @@ github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Peersyst/evmos/v19 v19.2.0-exrp.0 h1:euwjlXUZ4bg/QpcbhnJP/JKSZKm77A0ME8YnMbZ3JKU=
-github.com/Peersyst/evmos/v19 v19.2.0-exrp.0/go.mod h1:Lhs/n3iXgIb1uc5gYljhxzl80i9z5Lhs6GsPrlMMvg4=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=


### PR DESCRIPTION
# [FIX] Upgrade v3 error

## Motivation 💡

v3 upgrade was having errors when tried with the current devnet state

## Changes 🛠

- Adapt EVMOS '`x/evm` module to add the v5 to v6 migration
- Run module migrations before adding precompiles so the `x/evm` params are well validated
- Add `x/bank` denom metadata for XRP to work with `x/erc20` module
- Remove default EVMChannels from `x/evm` params
- Fix the release workflow