### PR TITLE
[FIX] Enable bank precompile in v3

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,4 +22,4 @@ jobs:
         run: |
           docker run --rm -e CGO_ENABLED -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
              -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/go/src/exrp -w /go/src/exrp \
-             goreleaser/goreleaser-cross:v1.20.2 release --clean --skip-validate
+             goreleaser/goreleaser-cross:v1.23.0 release --clean --skip-validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,4 @@ jobs:
         run: |
           docker run --rm -e CGO_ENABLED -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
              -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/go/src/exrp -w /go/src/exrp \
-             goreleaser/goreleaser-cross:v1.20.2 release --clean --skip-validate
+             goreleaser/goreleaser-cross:v1.23.0 release --clean --skip-validate

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -34,7 +34,6 @@ func (app *App) setupUpgradeHandlers() {
 		v3.CreateUpgradeHandler(
 			app.mm, app.configurator,
 			app.EvmKeeper,
-			app.Erc20Keeper,
 			app.AccountKeeper,
 			app.BankKeeper,
 		),


### PR DESCRIPTION
# [FIX] Enable bank precompile in v3

## Motivation 💡

Evmos team suggested to enable bank precompile

## Changes 🛠

- Enable bank precompile in v3 and remove unused upgrade logic
- Bump goreleaser to v1.23.0