### PR TITLE
[TA-3942]: Add common module upgrade tests

### DIFF
--- a/app/upgrades/v7/integration/auth_test.go
+++ b/app/upgrades/v7/integration/auth_test.go
@@ -1,0 +1,44 @@
+//nolint:dupl
+package integration
+
+import (
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_Auth_Params() {
+	prevParams, err := s.network.GetAuthClient().Params(
+		s.network.GetContext(),
+		&authtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetAuthClient().Params(
+		s.network.GetContext(),
+		&authtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_Auth_Accounts() {
+	res, err := s.network.GetAuthClient().Accounts(
+		s.network.GetContext(),
+		&authtypes.QueryAccountsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postRes, err := s.network.GetAuthClient().Accounts(
+		s.network.GetContext(),
+		&authtypes.QueryAccountsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified accounts are the same
+	s.Require().Equal(res.Accounts, postRes.Accounts)
+}

--- a/app/upgrades/v7/integration/bank_test.go
+++ b/app/upgrades/v7/integration/bank_test.go
@@ -2,6 +2,7 @@
 package integration
 
 import (
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
@@ -41,4 +42,62 @@ func (s *UpgradeTestSuite) TestUpgrade_Bank_TotalSupply() {
 
 	// Check that not modified balances are the same
 	s.Require().Equal(res.Supply, postRes.Supply)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_Bank_Send() {
+	// Replace with the desired addresses
+	sender, err := sdktypes.AccAddressFromBech32("ethm1dakgyqjulg29m5fmv992g2y66m9g2mjn6hahwg")
+	s.Require().NoError(err)
+	receiver, err := sdktypes.AccAddressFromBech32("ethm1nqvn2hmte72e3z0xyqmh06hdwd9qu6hgdcavhh")
+	s.Require().NoError(err)
+	amount := sdktypes.NewInt64Coin(s.network.GetDenom(), 100)
+
+	prevBalancesSender, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: sender.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	prevBalancesReceiver, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: receiver.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	err = s.network.BankKeeper().SendCoins(
+		s.network.GetContext(),
+		sender,
+		receiver,
+		sdktypes.NewCoins(amount),
+	)
+	s.Require().NoError(err)
+
+	postBalancesSender, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: sender.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	postBalancesReceiver, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: receiver.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	s.Require().Equal(prevBalancesSender.Balance.Amount.Sub(amount.Amount).String(), postBalancesSender.Balance.Amount.String())
+	s.Require().Equal(prevBalancesReceiver.Balance.Amount.Add(amount.Amount).String(), postBalancesReceiver.Balance.Amount.String())
 }

--- a/app/upgrades/v7/integration/bank_test.go
+++ b/app/upgrades/v7/integration/bank_test.go
@@ -1,0 +1,44 @@
+//nolint:dupl
+package integration
+
+import (
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_Bank_Params() {
+	prevParams, err := s.network.GetBankClient().Params(
+		s.network.GetContext(),
+		&banktypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetBankClient().Params(
+		s.network.GetContext(),
+		&banktypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_Bank_TotalSupply() {
+	res, err := s.network.GetBankClient().TotalSupply(
+		s.network.GetContext(),
+		&banktypes.QueryTotalSupplyRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postRes, err := s.network.GetBankClient().TotalSupply(
+		s.network.GetContext(),
+		&banktypes.QueryTotalSupplyRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified balances are the same
+	s.Require().Equal(res.Supply, postRes.Supply)
+}

--- a/app/upgrades/v7/integration/distribution_test.go
+++ b/app/upgrades/v7/integration/distribution_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_DistributionParams() {
+	prevParams, err := s.network.GetDistrClient().Params(
+		s.network.GetContext(),
+		&distributiontypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetDistrClient().Params(
+		s.network.GetContext(),
+		&distributiontypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}

--- a/app/upgrades/v7/integration/erc20_test.go
+++ b/app/upgrades/v7/integration/erc20_test.go
@@ -2,6 +2,8 @@
 package integration
 
 import (
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	erc20types "github.com/evmos/evmos/v20/x/erc20/types"
 )
 
@@ -41,4 +43,125 @@ func (s *UpgradeTestSuite) TestUpgrade_ERC20_TokenPairs() {
 
 	// Check that not modified token pairs are the same
 	s.Require().Equal(prevTokenPairs.TokenPairs, postTokenPairs.TokenPairs)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_ERC20_MintCoins() {
+	tokenPairs, err := s.network.GetERC20Client().TokenPairs(
+		s.network.GetContext(),
+		&erc20types.QueryTokenPairsRequest{},
+	)
+	s.Require().NoError(err)
+	s.Require().Equal(len(tokenPairs.TokenPairs), 1)
+
+	tokenPair := tokenPairs.TokenPairs[0]
+
+	sender, err := sdktypes.AccAddressFromBech32(tokenPair.OwnerAddress)
+	s.Require().NoError(err)
+
+	receiver, err := sdktypes.AccAddressFromBech32("ethm1dakgyqjulg29m5fmv992g2y66m9g2mjn6hahwg")
+	s.Require().NoError(err)
+
+	amount := sdktypes.NewInt64Coin(s.network.GetDenom(), 100)
+
+	prevBalancesReceiver, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: receiver.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+
+	s.RunUpgrade(upgradeName)
+
+	err = s.network.ERC20Keeper().MintCoins(
+		s.network.GetContext(),
+		sender,
+		receiver,
+		amount.Amount,
+		s.network.GetDenom(),
+	)
+	s.Require().NoError(err)
+
+	postBalancesReceiver, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: receiver.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	s.Require().Equal(prevBalancesReceiver.Balance.Amount.Add(amount.Amount).String(), postBalancesReceiver.Balance.Amount.String())
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_ERC20_BurnCoins() {
+	sender, err := sdktypes.AccAddressFromBech32("ethm1dakgyqjulg29m5fmv992g2y66m9g2mjn6hahwg")
+	s.Require().NoError(err)
+
+	amount := sdktypes.NewInt64Coin(s.network.GetDenom(), 100)
+
+	prevBalancesSender, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: sender.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	err = s.network.ERC20Keeper().BurnCoins(
+		s.network.GetContext(),
+		sender,
+		amount.Amount,
+		s.network.GetDenom(),
+	)
+	s.Require().NoError(err)
+
+	postBalancesSender, err := s.network.GetBankClient().Balance(
+		s.network.GetContext(),
+		&banktypes.QueryBalanceRequest{
+			Address: sender.String(),
+			Denom:   s.network.GetDenom(),
+		},
+	)
+	s.Require().NoError(err)
+
+	s.Require().Equal(prevBalancesSender.Balance.Amount.Sub(amount.Amount).String(), postBalancesSender.Balance.Amount.String())
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_ERC20_TransferOwnership() {
+	tokenPairs, err := s.network.GetERC20Client().TokenPairs(
+		s.network.GetContext(),
+		&erc20types.QueryTokenPairsRequest{},
+	)
+	s.Require().NoError(err)
+	s.Require().Equal(len(tokenPairs.TokenPairs), 1)
+
+	tokenPair := tokenPairs.TokenPairs[0]
+
+	sender, err := sdktypes.AccAddressFromBech32(tokenPair.OwnerAddress)
+	s.Require().NoError(err)
+
+	newOwner, err := sdktypes.AccAddressFromBech32("ethm1nqvn2hmte72e3z0xyqmh06hdwd9qu6hgdcavhh")
+	s.Require().NoError(err)
+
+	s.network.ERC20Keeper().TransferOwnership(
+		s.network.GetContext(),
+		sender,
+		newOwner,
+		tokenPair.Denom,
+	)
+	s.Require().NoError(err)
+
+	postTokenPair, err := s.network.GetERC20Client().TokenPair(
+		s.network.GetContext(),
+		&erc20types.QueryTokenPairRequest{
+			Token: tokenPair.Denom,
+		},
+	)
+	s.Require().NoError(err)
+
+	s.Require().Equal(newOwner.String(), postTokenPair.TokenPair.OwnerAddress)
 }

--- a/app/upgrades/v7/integration/erc20_test.go
+++ b/app/upgrades/v7/integration/erc20_test.go
@@ -1,0 +1,44 @@
+//nolint:dupl
+package integration
+
+import (
+	erc20types "github.com/evmos/evmos/v20/x/erc20/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_ERC20Params() {
+	prevParams, err := s.network.GetERC20Client().Params(
+		s.network.GetContext(),
+		&erc20types.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetERC20Client().Params(
+		s.network.GetContext(),
+		&erc20types.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_ERC20_TokenPairs() {
+	prevTokenPairs, err := s.network.GetERC20Client().TokenPairs(
+		s.network.GetContext(),
+		&erc20types.QueryTokenPairsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postTokenPairs, err := s.network.GetERC20Client().TokenPairs(
+		s.network.GetContext(),
+		&erc20types.QueryTokenPairsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified token pairs are the same
+	s.Require().Equal(prevTokenPairs.TokenPairs, postTokenPairs.TokenPairs)
+}

--- a/app/upgrades/v7/integration/evm_test.go
+++ b/app/upgrades/v7/integration/evm_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_EvmParams() {
+	prevParams, err := s.network.GetEvmClient().Params(
+		s.network.GetContext(),
+		&evmtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetEvmClient().Params(
+		s.network.GetContext(),
+		&evmtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}

--- a/app/upgrades/v7/integration/feemarket_test.go
+++ b/app/upgrades/v7/integration/feemarket_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	feemarkettypes "github.com/evmos/evmos/v20/x/feemarket/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_FeeMarketParams() {
+	prevParams, err := s.network.GetFeeMarketClient().Params(
+		s.network.GetContext(),
+		&feemarkettypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetFeeMarketClient().Params(
+		s.network.GetContext(),
+		&feemarkettypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}

--- a/app/upgrades/v7/integration/gov_test.go
+++ b/app/upgrades/v7/integration/gov_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_GovParams() {
+	prevParams, err := s.network.GetGovClient().Params(
+		s.network.GetContext(),
+		&govtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetGovClient().Params(
+		s.network.GetContext(),
+		&govtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}

--- a/app/upgrades/v7/integration/network.go
+++ b/app/upgrades/v7/integration/network.go
@@ -1,4 +1,4 @@
-package tests
+package integration
 
 import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
@@ -7,6 +7,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	erc20types "github.com/evmos/evmos/v20/x/erc20/types"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
@@ -64,6 +65,10 @@ func (n *UpgradeTestNetwork) GetAuthzClient() authz.QueryClient {
 
 func (n *UpgradeTestNetwork) GetStakingClient() stakingtypes.QueryClient {
 	return exrpcommon.GetStakingClient(n)
+}
+
+func (n *UpgradeTestNetwork) GetSlashingClient() slashingtypes.QueryClient {
+	return exrpcommon.GetSlashingClient(n)
 }
 
 func (n *UpgradeTestNetwork) GetDistrClient() distrtypes.QueryClient {

--- a/app/upgrades/v7/integration/poa_test.go
+++ b/app/upgrades/v7/integration/poa_test.go
@@ -1,0 +1,98 @@
+package integration
+
+import (
+	"time"
+
+	"math/rand"
+
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	poatypes "github.com/xrplevm/node/v6/x/poa/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_Poa_ExecuteRemoveValidator() {
+	validators, err := s.network.GetStakingClient().Validators(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorsRequest{},
+	)
+	s.Require().NoError(err)
+	s.Require().Greater(len(validators.Validators), 0)
+
+	validator := validators.Validators[0]
+	valAddr, err := sdktypes.ValAddressFromBech32(validator.OperatorAddress)
+	s.Require().NoError(err)
+	valAccAddr := sdktypes.AccAddress(valAddr)
+
+	_, err = s.network.GetStakingClient().Validator(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorRequest{
+			ValidatorAddr: validator.OperatorAddress,
+		},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	s.network.PoaKeeper().ExecuteRemoveValidator(
+		s.network.GetContext(),
+		valAccAddr.String(),
+	)
+	s.Require().NoError(err)
+	
+
+	postValidator, err := s.network.GetStakingClient().Validator(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorRequest{
+			ValidatorAddr: validator.OperatorAddress,
+		},
+	)
+
+	s.Require().NoError(err)
+	s.Require().True(postValidator.Validator.Tokens.IsZero(), "validator tokens should be zero")
+	s.Require().True(postValidator.Validator.DelegatorShares.RoundInt().IsZero(), "validator delegator shares should be zero")
+}
+
+func (s *UpgradeTestSuite)  TestUpgrade_Poa_ExecuteAddValidator() {
+	randomAccs := simtypes.RandomAccounts(rand.New(rand.NewSource(time.Now().UnixNano())), 1) //nolint:gosec
+	randomAcc := randomAccs[0]
+		randomValAddr := sdktypes.ValAddress(randomAcc.Address.Bytes())
+
+	authority := sdktypes.AccAddress(address.Module("gov"))
+	msg, err := poatypes.NewMsgAddValidator(
+		authority.String(),
+		randomAcc.Address.String(),
+		randomAcc.ConsKey.PubKey(),
+		stakingtypes.Description{
+			Moniker: "test",
+		},
+	)
+
+	_, err = s.network.GetStakingClient().Validator(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorRequest{
+			ValidatorAddr: randomValAddr.String(),
+		},
+	)
+	s.Require().Error(err)
+
+	s.RunUpgrade(upgradeName)
+
+	err = s.network.PoaKeeper().ExecuteAddValidator(
+		s.network.GetContext(),
+		msg,
+	)
+	s.Require().NoError(err)
+	
+	val, err := s.network.GetStakingClient().Validator(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorRequest{
+			ValidatorAddr: randomValAddr.String(),
+		},
+	)
+	s.Require().NoError(err)
+	s.Require().Equal(val.Validator.Status, stakingtypes.Unbonded)
+	s.Require().Equal(val.Validator.Tokens, sdktypes.DefaultPowerReduction)
+	s.Require().Equal(val.Validator.DelegatorShares, sdktypes.DefaultPowerReduction.ToLegacyDec())
+}

--- a/app/upgrades/v7/integration/slashing_test.go
+++ b/app/upgrades/v7/integration/slashing_test.go
@@ -1,0 +1,44 @@
+//nolint:dupl
+package integration
+
+import (
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_SlashingParams() {
+	prevParams, err := s.network.GetSlashingClient().Params(
+		s.network.GetContext(),
+		&slashingtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetSlashingClient().Params(
+		s.network.GetContext(),
+		&slashingtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params, postParams.Params)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_Slashing_SigningInfos() {
+	prevSigningInfos, err := s.network.GetSlashingClient().SigningInfos(
+		s.network.GetContext(),
+		&slashingtypes.QuerySigningInfosRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postSigningInfos, err := s.network.GetSlashingClient().SigningInfos(
+		s.network.GetContext(),
+		&slashingtypes.QuerySigningInfosRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified signing infos are the same
+	s.Require().Equal(prevSigningInfos.Info, postSigningInfos.Info)
+}

--- a/app/upgrades/v7/integration/staking_test.go
+++ b/app/upgrades/v7/integration/staking_test.go
@@ -1,0 +1,69 @@
+package integration
+
+import (
+	"time"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+func (s *UpgradeTestSuite) TestUpgrade_Staking_Params() {
+	prevParams, err := s.network.GetStakingClient().Params(
+		s.network.GetContext(),
+		&stakingtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postParams, err := s.network.GetStakingClient().Params(
+		s.network.GetContext(),
+		&stakingtypes.QueryParamsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified params are the same
+	s.Require().Equal(prevParams.Params.BondDenom, postParams.Params.BondDenom)
+	s.Require().Equal(prevParams.Params.MaxValidators, postParams.Params.MaxValidators)
+	s.Require().Equal(prevParams.Params.MinCommissionRate, postParams.Params.MinCommissionRate)
+	s.Require().Equal(prevParams.Params.MaxEntries, postParams.Params.MaxEntries)
+	s.Require().Equal(prevParams.Params.HistoricalEntries, postParams.Params.HistoricalEntries)
+
+	// Check that unbonding time was modified
+	s.Require().Equal(postParams.Params.UnbondingTime, 100*time.Second)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_Staking_Validators() {
+	res, err := s.network.GetStakingClient().Validators(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorsRequest{},
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postRes, err := s.network.GetStakingClient().Validators(
+		s.network.GetContext(),
+		&stakingtypes.QueryValidatorsRequest{},
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified validators are the same
+	s.Require().Equal(res.Validators, postRes.Validators)
+}
+
+func (s *UpgradeTestSuite) TestUpgrade_Staking_Delegations() {
+	prevDelegations, err := s.network.StakingKeeper().GetAllDelegations(
+		s.network.GetContext(),
+	)
+	s.Require().NoError(err)
+
+	s.RunUpgrade(upgradeName)
+
+	postDelegations, err := s.network.StakingKeeper().GetAllDelegations(
+		s.network.GetContext(),
+	)
+	s.Require().NoError(err)
+
+	// Check that not modified delegations are the same
+	s.Require().Equal(prevDelegations, postDelegations)
+}

--- a/app/upgrades/v7/integration/suite.go
+++ b/app/upgrades/v7/integration/suite.go
@@ -1,9 +1,16 @@
-package tests
+package integration
 
 import (
+	"os/exec"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 	exrpupgrade "github.com/xrplevm/node/v6/testutil/integration/exrp/upgrade"
+)
+
+const (
+	upgradeName = "v7.0.0"
 )
 
 type UpgradeTestSuite struct {
@@ -16,19 +23,42 @@ func (s *UpgradeTestSuite) Network() *UpgradeTestNetwork {
 	return s.network
 }
 
-func (s *UpgradeTestSuite) SetupTest() {
+func (s *UpgradeTestSuite) SetupSuite() {
 	// Setup the SDK config
 	s.network.SetupSdkConfig()
 
 	s.Require().Equal(sdk.GetConfig().GetBech32AccountAddrPrefix(), "ethm")
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	s.Require().NoError(exec.Command("cp", "-r", ".exrpd", ".exrpd-v7").Run())
 
 	// Create the network
 	s.network = NewUpgradeTestNetwork(
-		exrpupgrade.WithUpgradePlanName("v7.0.0"),
-		exrpupgrade.WithDataDir(".exrpd/data"),
+		exrpupgrade.WithUpgradePlanName(upgradeName),
+		exrpupgrade.WithDataDir(".exrpd-v7/data"),
 		exrpupgrade.WithNodeDBName("application"),
 	)
+}
 
-	// Check that the network was created successfully
-	s.Require().NotNil(s.network)
+func (s *UpgradeTestSuite) TearDownTest() {
+	s.Require().NoError(exec.Command("rm", "-rf", ".exrpd-v7").Run())
+}
+
+func (s *UpgradeTestSuite) RunUpgrade(name string) {
+	res, err := s.network.GetUpgradeClient().CurrentPlan(
+		s.network.GetContext(),
+		&upgradetypes.QueryCurrentPlanRequest{},
+	)
+	s.Require().NoError(err)
+	s.Require().Equal(name, res.Plan.Name)
+
+	s.Require().True(s.Network().UpgradeKeeper().HasHandler(name))
+
+	err = s.network.UpgradeKeeper().ApplyUpgrade(
+		s.Network().GetContext(),
+		*res.Plan,
+	)
+
+	s.Require().NoError(err)
 }

--- a/app/upgrades/v7/integration/suite.go
+++ b/app/upgrades/v7/integration/suite.go
@@ -6,6 +6,9 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
+	"github.com/xrplevm/node/v6/testutil/integration/common/grpc"
+	"github.com/xrplevm/node/v6/testutil/integration/common/keyring"
+	exrpcommon "github.com/xrplevm/node/v6/testutil/integration/exrp/common"
 	exrpupgrade "github.com/xrplevm/node/v6/testutil/integration/exrp/upgrade"
 )
 
@@ -17,6 +20,8 @@ type UpgradeTestSuite struct {
 	suite.Suite
 
 	network *UpgradeTestNetwork
+		keyring     keyring.Keyring
+	grpcHandler grpc.Handler
 }
 
 func (s *UpgradeTestSuite) Network() *UpgradeTestNetwork {
@@ -31,6 +36,9 @@ func (s *UpgradeTestSuite) SetupSuite() {
 }
 
 func (s *UpgradeTestSuite) SetupTest() {
+	// Check that the network was created successfully
+	kr := keyring.New(5)
+
 	s.Require().NoError(exec.Command("cp", "-r", ".exrpd", ".exrpd-v7").Run())
 
 	// Create the network
@@ -38,7 +46,14 @@ func (s *UpgradeTestSuite) SetupTest() {
 		exrpupgrade.WithUpgradePlanName(upgradeName),
 		exrpupgrade.WithDataDir(".exrpd-v7/data"),
 		exrpupgrade.WithNodeDBName("application"),
+		exrpcommon.WithBondDenom("apoa"),
+		exrpcommon.WithDenom("token"),
 	)
+
+	rpcHandler := grpc.NewIntegrationHandler(s.network)
+
+	s.grpcHandler = rpcHandler
+	s.keyring = kr
 }
 
 func (s *UpgradeTestSuite) TearDownTest() {
@@ -61,4 +76,6 @@ func (s *UpgradeTestSuite) RunUpgrade(name string) {
 	)
 
 	s.Require().NoError(err)
+
+
 }

--- a/app/upgrades/v7/integration/suite_test.go
+++ b/app/upgrades/v7/integration/suite_test.go
@@ -1,40 +1,11 @@
-package tests
+package integration
 
 import (
 	"testing"
-	"time"
 
-	upgradetypes "cosmossdk.io/x/upgrade/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestUpgradeTestSuite(t *testing.T) {
 	suite.Run(t, new(UpgradeTestSuite))
-}
-
-func (s *UpgradeTestSuite) TestUpgradeV7() {
-	res, err := s.network.GetUpgradeClient().CurrentPlan(
-		s.network.GetContext(),
-		&upgradetypes.QueryCurrentPlanRequest{},
-	)
-	s.Require().NoError(err)
-	s.Require().Equal("v7.0.0", res.Plan.Name)
-
-	s.Require().True(s.Network().UpgradeKeeper().HasHandler("v7.0.0"))
-
-	err = s.network.UpgradeKeeper().ApplyUpgrade(
-		s.Network().GetContext(),
-		*res.Plan,
-	)
-
-	s.Require().NoError(err)
-
-	resParams, err := s.network.GetStakingClient().Params(
-		s.network.GetContext(),
-		&stakingtypes.QueryParamsRequest{},
-	)
-
-	s.Require().NoError(err)
-	s.Require().Equal(100*time.Second, resParams.Params.UnbondingTime)
 }

--- a/testutil/integration/common/network/network.go
+++ b/testutil/integration/common/network/network.go
@@ -45,7 +45,6 @@ type Network interface {
 	GetDistrClient() distrtypes.QueryClient
 	GetFeeMarketClient() feemarkettypes.QueryClient
 	GetGovClient() govtypes.QueryClient
-
 	BroadcastTxSync(txBytes []byte) (abcitypes.ExecTxResult, error)
 	Simulate(txBytes []byte) (*txtypes.SimulateResponse, error)
 	CheckTx(txBytes []byte) (*abcitypes.ResponseCheckTx, error)

--- a/testutil/integration/exrp/upgrade/keepers.go
+++ b/testutil/integration/exrp/upgrade/keepers.go
@@ -10,6 +10,7 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	erc20keeper "github.com/evmos/evmos/v20/x/erc20/keeper"
 	evmkeeper "github.com/evmos/evmos/v20/x/evm/keeper"
 	feemarketkeeper "github.com/evmos/evmos/v20/x/feemarket/keeper"
@@ -62,4 +63,8 @@ func (n *UpgradeIntegrationNetwork) PoaKeeper() poakeeper.Keeper {
 
 func (n *UpgradeIntegrationNetwork) UpgradeKeeper() upgradekeeper.Keeper {
 	return *n.app.UpgradeKeeper
+}
+
+func (n *UpgradeIntegrationNetwork) ParamsKeeper() paramskeeper.Keeper {
+	return n.app.ParamsKeeper
 }


### PR DESCRIPTION
#[TA-3942]: Add module upgrade tests

## Motivation 💡

This PR aims to add upgrade integration tests for the following common modules with the goal of improve testing coverage:

- [x]  account
- [x]  bank
- [x]  staking
- [x]  slashing
- [x]  gov
- [x]  evm
- [x]  distribution
- [x]  feemarket
- [x]  erc20
- [x]  poa

## Changes 🛠

- Added `auth` tests
- Added `bank` tests
- Added `staking` tests
- Added `slashing` tests
- Added `gov` tests
- Added `evm` tests
- Added `distribution` tests
- Added `feemarket` tests
- Added `erc20` tests
- Added `poa` tests
