### PR TITLE
[IF-FINDING-003] Minimum and maximum validator number validation

### DIFF
--- a/x/poa/keeper/keeper.go
+++ b/x/poa/keeper/keeper.go
@@ -89,6 +89,7 @@ func (k Keeper) ExecuteAddValidator(ctx sdk.Context, msg *types.MsgAddValidator)
 	if err != nil {
 		return err
 	}
+	//nolint:gosec
 	if uint32(len(validators)) >= params.MaxValidators {
 		return types.ErrMaxValidatorsReached
 	}

--- a/x/poa/keeper/keeper.go
+++ b/x/poa/keeper/keeper.go
@@ -89,7 +89,7 @@ func (k Keeper) ExecuteAddValidator(ctx sdk.Context, msg *types.MsgAddValidator)
 	if err != nil {
 		return err
 	}
-	if len(validators) >= int(params.MaxValidators) {
+	if uint32(len(validators)) >= params.MaxValidators {
 		return types.ErrMaxValidatorsReached
 	}
 

--- a/x/poa/keeper/keeper.go
+++ b/x/poa/keeper/keeper.go
@@ -83,6 +83,16 @@ func (k Keeper) ExecuteAddValidator(ctx sdk.Context, msg *types.MsgAddValidator)
 	if err != nil {
 		return err
 	}
+
+	// Check if the maximum number of validators has been reached
+	validators, err := k.sk.GetAllValidators(ctx)
+	if err != nil {
+		return err
+	}
+	if len(validators) >= int(params.MaxValidators) {
+		return types.ErrMaxValidatorsReached
+	}
+
 	denom := params.BondDenom
 	balance := k.bk.GetBalance(ctx, accAddress, denom)
 	if !balance.IsZero() {

--- a/x/poa/keeper/keeper_test.go
+++ b/x/poa/keeper/keeper_test.go
@@ -20,7 +20,8 @@ func poaKeeperTestSetup(t *testing.T) (*Keeper, sdk.Context) {
 		stakingHooks.EXPECT().BeforeValidatorSlashed(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		stakingKeeper.EXPECT().GetParams(ctx).Return(stakingtypes.Params{
-			BondDenom: "XRP",
+			BondDenom:     "XRP",
+			MaxValidators: 32,
 		}, nil).AnyTimes()
 		stakingKeeper.EXPECT().GetValidator(ctx, gomock.Any()).Return(stakingtypes.Validator{Tokens: math.NewInt(0)}, nil).AnyTimes()
 		stakingKeeper.EXPECT().GetAllDelegatorDelegations(ctx, gomock.Any()).Return([]stakingtypes.Delegation{}, nil).AnyTimes()
@@ -32,6 +33,7 @@ func poaKeeperTestSetup(t *testing.T) (*Keeper, sdk.Context) {
 		stakingKeeper.EXPECT().BondDenom(ctx).Return("XRP", nil).AnyTimes()
 		stakingKeeper.EXPECT().Unbond(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(math.ZeroInt(), nil).AnyTimes()
 		stakingKeeper.EXPECT().Hooks().Return(stakingHooks).AnyTimes()
+		stakingKeeper.EXPECT().GetAllValidators(ctx).Return([]stakingtypes.Validator{}, nil).AnyTimes()
 	}
 
 	bankExpectations := func(ctx sdk.Context, bankKeeper *testutil.MockBankKeeper) {

--- a/x/poa/types/errors.go
+++ b/x/poa/types/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrAddressHasUnbondedTokens  = sdkerrors.Register(ModuleName, 6, "address already has unbonded tokens")
 	ErrAddressHasDelegatedTokens = sdkerrors.Register(ModuleName, 7, "address already has delegated tokens")
 	ErrInvalidValidatorStatus    = sdkerrors.Register(ModuleName, 8, "invalid validator status")
+	ErrMaxValidatorsReached      = sdkerrors.Register(ModuleName, 9, "maximum number of validators reached")
 )


### PR DESCRIPTION
# [IF-FINDING-003] ~~Minimum~~ and maximum validator number validation

## Description

Taking into consideration that in Proof of Authority (PoA), all validators have the same voting power, and that the Cosmos SDK staking module determines which validators are included in the active set based on their voting power, an issue arises when the maximum number of validators has already been reached.
If a new validator is added under these conditions, since it has the same voting power as the existing ones, the selection process may be affected by the validator’s address rather than its power. This means that a validator could be excluded from the active set not due to voting power differences, but simply due to address ordering.
To prevent this, a maximum validator count check should be enforced to block additional validators once the limit is reached—or at least until this limit is intentionally increased.
~~Additionally, when removing a validator a check if the minimum number of validators is reached should be added, just to prevent situations where the number of validators is to small so that even one validator is enough to break >1/3 number of byzantine validators Tendermint assumption.~~


## Problem scenarios

- Validator admission to the active set can become dependent on its address.
- ~~A minimum number of validators can be reached where a single byzantine validator is enough to break the >1/3 number of byzantine validators Tendermint assumption.~~

## Recommendation

Introduce a ~~minimum~~ and a maximum number of validators check in methods to remove and add validator.

## Applied changes

Add a check in `AddValidator` function inside `keeper.go` that checks if the number of validators exceeds the Maximum set in staking params