### PR TITLE
fix: bump cosmos/evm fork to v0.6.1-xrplevm.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,7 @@ replace (
 	// use Cosmos-SDK fork to enable Ledger functionality
 	github.com/cosmos/cosmos-sdk => github.com/xrplevm/cosmos-sdk v0.53.6-xrplevm.1
 	// cosmos evm private fork
-	github.com/cosmos/evm => github.com/xrplevm/evm v0.6.1-xrplevm.1
+	github.com/cosmos/evm => github.com/xrplevm/evm v0.6.1-xrplevm.2
 	// fix cosmos-sdk store path mismatch
 	// github.com/cosmos/cosmos-sdk/store => cosmossdk.io/store v1.1.2
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v0.0.0-20250806193535-2fc7571efa91

--- a/go.sum
+++ b/go.sum
@@ -1727,8 +1727,8 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/xrplevm/cosmos-sdk v0.53.6-xrplevm.1 h1:fBMklkMKZbrVoEhGU0JyeaINkRA9lVA9K/zRY73EGh0=
 github.com/xrplevm/cosmos-sdk v0.53.6-xrplevm.1/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
-github.com/xrplevm/evm v0.6.1-xrplevm.1 h1:YrB+qiTo59Hh0SMzn6V6/z4v9lgbSSwWfAFVIjpHFeY=
-github.com/xrplevm/evm v0.6.1-xrplevm.1/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
+github.com/xrplevm/evm v0.6.1-xrplevm.2 h1:UaL8U99chl+EOC7YeIS4g6YdzKbWq/HmVJMZaRedd5s=
+github.com/xrplevm/evm v0.6.1-xrplevm.2/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Bumps the `cosmos/evm` fork pin from `v0.6.1-xrplevm.1` to [`v0.6.1-xrplevm.2`](https://github.com/xrplevm/evm/releases/tag/v0.6.1-xrplevm.2), which carries the backport of [cosmos/evm#1107](https://github.com/cosmos/evm/pull/1107) ([xrplevm/evm#13](https://github.com/xrplevm/evm/pull/13)).

## Why

Testnet block `8005874` cannot be served by any block-level JSON-RPC method. Every call fails permanently with:

```
-32000: failed to get rpc block from comet block: failed to get receipts from comet block:
        failed to convert tx result to eth receipt: invalid message index: 0
```

Downstream indexers cannot advance past that height.

The block contains a tx that sends non-zero native value to the `ecrecover` precompile. Precompile addresses are on the bank module's blocked list, so the balance write is rejected at commit time and the whole cosmos tx fails (`code: 4`, `data: null`). The JSON-RPC layer nonetheless included that tx in the ethereum view of the block and then tried to decode its logs from the empty payload, which is fatal for the whole block.

The fix excludes this class of tx from the ethereum view of the block. It shipped upstream in `v0.7.0` and had never been backported to the `v0.6.x` line, which is what we run.

## Scope

`go.mod` (1 line) and `go.sum` (2 lines). No code changes.

Read-path change only — no state migration, no resync, no consensus impact. Nodes just need the new binary. After deploying, block `8005874` serves normally; the failed tx is excluded from the ethereum view of the block and its receipt returns null, which is the upstream-intended behaviour (the tx reverted entirely, only the fee was charged).

## Verification

- `go build ./...` passes.
- `go test -mod=readonly -tags=test ./tests/integration` passes.
- `x/poa/{ante,keeper,simulation,types}` pass.
- Confirmed the module the node now compiles against carries the fix: `TxSucessOrExpectedFailure` no longer has the `TxStateDBCommitError` clause, and the regression test is present.

`app.TestFullAppSimulation` fails with `denom metadata axrp could not be found`, but it fails identically on `main` with the same invocation, so it is pre-existing and unrelated to this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the underlying EVM component to a newer XRPL EVM fork version, providing the latest available fixes and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->